### PR TITLE
Fix greedy regexp

### DIFF
--- a/po2json.js
+++ b/po2json.js
@@ -1,6 +1,6 @@
 module.exports = function(text, jsFile) {
-	var singularRegex = new RegExp('msgid "(.*?)"\nmsgstr "(.*?)"', 'g');
-	var pluralRegex = new RegExp('msgid "(.*?)"\nmsgid_plural "(.*?)"\nmsgstr\\[0\\] "(.*?)"\nmsgstr\\[1\\] "(.*?)"', 'g');
+	var singularRegex = new RegExp('msgid "(.*?)"\nmsgstr "(.*?)"\n', 'g');
+	var pluralRegex = new RegExp('msgid "(.*?)"\nmsgid_plural "(.*?)"\nmsgstr\\[0\\] "(.*?)"\nmsgstr\\[1\\] "(.*?)"\n', 'g');
 
 	var translations = {};
 


### PR DESCRIPTION
If the translated string has a quote in it, the regexp ends earlier and the resulting js file is missing translation pieces.